### PR TITLE
v0.6 example using base: core18

### DIFF
--- a/v_0.6_core18/snap/snapcraft.yaml
+++ b/v_0.6_core18/snap/snapcraft.yaml
@@ -1,0 +1,106 @@
+name: testsnap-py # you probably want to 'snapcraft register <name>'
+version: '0.6' # just for humans, typically '1.2+git' or '1.3.2'
+summary: Single-line elevator pitch for your amazing snap # 79 char long summary
+description: |
+  Example of a Python 3.6 snap using wxPython 4.0.4 built using the 'core18'
+  technique, which builds via a multipass virtual machine and core18 image.
+
+  This example is different to v_0.5.1 in that the #after: [desktop-gtk3]
+  line has been commented out and replaced with the entire desktop-gtk3:
+  part. This is because snaps built with core18 cannot refer to remote parts
+  thus parts must be explicitly listed.
+
+  To build this snap:
+    snapcraft
+  If you get trouble
+    snapcraft clean
+
+  Tip: since specifying parts or a step name is not yet supported (as of March 2019) these won't work:
+    snapcraft clean testsnap-py -s pull
+    snapcraft clean testsnap-py
+
+  Install the snap locally
+    sudo snap install --devmode --dangerous *.snap
+    snap list
+
+  Run
+    testsnap-py
+
+  Ignore the warnings Gtk-Message: Failed to load module "canberra-gtk-module"
+  as these seem to happen to all snaps?
+
+  Publish
+    snapcraft login (use ubuntu one auth)
+    snapcraft register testsnap-py
+    snapcraft push --release=edge *.snap
+
+
+  Note that you should rename all references to "testsnap-py" in this file to "yourapp"
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: strict # use 'strict' once you have the right plugs and slots
+base: core18
+
+apps:
+    testsnap-py:
+        command: desktop-launch python3 $SNAP/usr/bin/testsnap.py
+        plugs: [x11, unity7, pulseaudio, home, gsettings, network]
+        environment:
+            LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$SNAP/usr/lib/x86_64-linux-gnu/pulseaudio
+
+parts:
+  desktop-gtk3:
+    build-packages:
+    - build-essential
+    - libgtk-3-dev
+    make-parameters:
+    - FLAVOR=gtk3
+    plugin: make
+    source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
+    source-subdir: gtk
+    stage-packages:
+    - libxkbcommon0
+    - ttf-ubuntu-font-family
+    - dmz-cursor-theme
+    - light-themes
+    - adwaita-icon-theme
+    - gnome-themes-standard
+    - shared-mime-info
+    - libgtk-3-0
+    - libgdk-pixbuf2.0-0
+    - libglib2.0-bin
+    - libgtk-3-bin
+    - unity-gtk3-module
+    - libappindicator3-1
+    - locales-all
+    - xdg-user-dirs
+    - ibus-gtk3
+    - libibus-1.0-5
+    - fcitx-frontend-gtk3
+  testsnap-py:
+    # See 'snapcraft plugins'
+    plugin: python
+    python-version: python3
+    source: .
+    stage-packages:
+        # - libc6
+        - libssl-dev
+        - libjpeg-dev
+        - libtiff-dev
+        - libsdl1.2-dev
+        - libnotify-dev
+        - freeglut3
+        - ibus-gtk3
+        - libwebkitgtk-3.0-0
+        - zlib1g
+        - libsm6
+        - libpulse0
+        - libslang2
+    #after: [desktop-gtk3]
+    python-packages:
+        #- https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-18.04/wxPython-4.0.4-cp37-cp37m-linux_x86_64.whl
+        - https://extras.wxpython.org/wxPython4/extras/linux/gtk3/ubuntu-18.04/wxPython-4.0.4-cp36-cp36m-linux_x86_64.whl
+    override-build: |
+        snapcraftctl build
+        cp $SNAPCRAFT_PART_SRC/testsnap.py $SNAPCRAFT_PART_INSTALL/usr/bin/
+        chmod +x $SNAPCRAFT_PART_INSTALL/usr/bin/testsnap.py

--- a/v_0.6_core18/testsnap.py
+++ b/v_0.6_core18/testsnap.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+
+import wx
+from wx.html2 import WebView
+
+
+class MyTestFrame(wx.Frame):
+    def __init__(self, parent, title):
+        super().__init__(parent, wx.ID_ANY, title, size=(1200, 700))
+
+        bSizer9 = wx.BoxSizer(wx.VERTICAL)
+
+        self._browser = WebView.New(self)
+        bSizer9.Add(self._browser, 1, wx.ALL | wx.EXPAND, 5)  # widget, proportion, flags, border
+
+        bSizer8 = wx.BoxSizer(wx.HORIZONTAL)
+        for i in range(5):
+            btn = wx.Button(self, wx.ID_OK, f"Btn{i}", wx.DefaultPosition, wx.DefaultSize, 0)
+            bSizer8.Add(btn, 0, wx.ALL | wx.EXPAND, 5)
+            self.Bind(wx.EVT_BUTTON, self.OnButtonClick, btn)
+        bSizer9.Add(bSizer8, 0)
+
+        self.SetSizer(bSizer9)
+        self.Layout()
+
+        # self._browser.LoadURL('http://pynsource.com')
+        self._browser.LoadURL('http://google.com')
+
+        self.Show()
+
+    def OnButtonClick(self, event):
+        button = event.GetEventObject()  # get the button that was clicked
+        wx.MessageBox(f"Hi from a button click {button.GetLabel()}")
+
+
+if __name__ == '__main__':
+    app = wx.App()
+    frame = MyTestFrame(None, 'Test')
+    app.MainLoop()


### PR DESCRIPTION
Hi Eugeniy,

I created a new example version 0.6 which has a `snapfile.yaml` that builds successfully using the base: core18 technique.

Remember there was an issue about this: Jenyay/snap-examples#2
I even successfully published it to https://snapcraft.io/andy-testsnap-py

I also added a bit more complexity to the wxPython app by adding some buttons. I changed the url to be google, but if you want, you can change it back to your own website.

Up to you if you want to accept this pull request to add to your list of examples - just thought I would help out and it might help others.

cheers,
Andy